### PR TITLE
Change capabilities to DSTs (and tweaks)

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,7 @@ use terminfo::{Expand, Database, capability as cap};
 fn main() {
   let info = Database::from_env().unwrap();
 
-  if let Some(cap::MaxColors(n)) = info.get::<cap::MaxColors>() {
+  if let Some(&cap::MaxColors(n)) = info.get::<cap::MaxColors>() {
     println!("The terminal supports {} colors.", n);
   }
   else {

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -72,9 +72,9 @@ macro_rules! define {
 			}
 		}
 
-		impl Into<bool> for $ident {
-			fn into(self) -> bool {
-				self.0
+		impl From<$ident> for bool {
+			fn from(cap: $ident) -> bool {
+				cap.0
 			}
 		}
 	);
@@ -100,9 +100,9 @@ macro_rules! define {
 			}
 		}
 
-		impl Into<i16> for $ident {
-			fn into(self) -> i16 {
-				self.0
+		impl From<$ident> for i16 {
+			fn from(cap: $ident) -> i16 {
+				cap.0
 			}
 		}
 	);

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -18,15 +18,15 @@ use expand::{Expand, Parameter, Context};
 use error;
 
 /// A trait for any object that will represent a terminal capability.
-pub trait Capability<'a>: Sized {
+pub trait Capability {
 	/// Returns the name of the capability in its long form.
 	fn name() -> &'static str;
 
 	/// Lookup a capability in a database
-	fn lookup(db: &'a ::Database) -> Option<Self>;
+	fn lookup(db: &::Database) -> Option<&Self>;
 }
 
-/// Possible value types for capabilities.
+/// Possible values for capabilities.
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub enum Value {
 	/// A boolean.
@@ -52,20 +52,22 @@ impl Expand for Value {
 
 macro_rules! define {
 	(boolean $ident:ident => $name:expr) => (
-		#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+		#[derive(Eq, PartialEq, Debug)]
 		pub struct $ident(pub bool);
 
-		impl<'a> Capability<'a> for $ident {
+		impl Capability for $ident {
 			#[inline]
 			fn name() -> &'static str {
 				$name
 			}
 
 			#[inline]
-			fn lookup(db: &'a ::Database) -> Option<Self> {
+			fn lookup(db: &::Database) -> Option<&Self> {
+				static TRUE: $ident = $ident(true);
+				static FALSE: $ident = $ident(false);
 				Some(match db.raw(Self::name()) {
-					Some(&Value::Boolean(true)) => $ident(true),
-					None => $ident(false),
+					Some(&Value::Boolean(true)) => &TRUE,
+					None => &FALSE,
 					_ => panic!("invalid database"),
 				})
 			}
@@ -76,22 +78,31 @@ macro_rules! define {
 				cap.0
 			}
 		}
+
+		// Not strictly necessary but rust misses this deref due to generics.
+		impl<'a> From<&'a $ident> for bool {
+			fn from(cap: &'a $ident) -> bool {
+				cap.0
+			}
+		}
 	);
 
 	(number $ident:ident => $name:expr) => (
-		#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+		#[derive(Eq, PartialEq, Debug)]
 		pub struct $ident(pub i16);
 
-		impl<'a> Capability<'a> for $ident {
+		impl Capability for $ident {
 			#[inline]
 			fn name() -> &'static str {
 				$name
 			}
 
 			#[inline]
-			fn lookup(db: &'a ::Database) -> Option<Self> {
+			fn lookup<'a>(db: &::Database) -> Option<&Self> {
 				match db.raw(Self::name()) {
-					Some(&Value::Number(num)) => Some($ident(num)),
+					Some(&Value::Number(ref num)) => unsafe {
+						Some(&*(num as *const i16 as *const $ident))
+					},
 					None => None,
 					_ => panic!("invalid database"),
 				}
@@ -103,35 +114,46 @@ macro_rules! define {
 				cap.0
 			}
 		}
+
+		// Not strictly necessary but rust misses this deref due to generics.
+		impl<'a> From<&'a $ident> for i16 {
+			fn from(cap: &'a $ident) -> i16 {
+				cap.0
+			}
+		}
 	);
 
 	(string $ident:ident => $name:expr) => (
-		#[derive(Eq, PartialEq, Copy, Clone, Debug)]
-		pub struct $ident<'a>(&'a [u8]);
+		#[derive(Eq, PartialEq, Debug)]
+		pub struct $ident(pub [u8]);
 
-		impl<'a> AsRef<[u8]> for $ident<'a> {
-			fn as_ref(&self) -> &[u8] {
-				self.0
-			}
-		}
 
-		impl<'a> Capability<'a> for $ident<'a> {
+		impl Capability for $ident {
 			#[inline]
 			fn name() -> &'static str {
 				$name
 			}
 
 			#[inline]
-			fn lookup(db: &'a ::Database) -> Option<Self> {
+			fn lookup<'a>(db: &'a ::Database) -> Option<&'a Self> {
 				match db.raw(Self::name()) {
-					Some(&Value::String(ref s)) => Some($ident(&**s)),
+					Some(&Value::String(ref s)) => unsafe {
+						Some(&*(&**s as *const [u8] as *const $ident))
+					},
 					None => None,
 					_ => panic!("invalid database"),
 				}
 			}
 		}
 
-		impl<'a> Expand for $ident<'a> {
+
+		impl AsRef<[u8]> for $ident {
+			fn as_ref(&self) -> &[u8] {
+				&self.0
+			}
+		}
+
+		impl Expand for $ident {
 			fn expand(&self, parameters: &[Parameter], context: &mut Context) -> error::Result<Vec<u8>> {
 				self.0.expand(parameters, context)
 			}

--- a/src/database.rs
+++ b/src/database.rs
@@ -164,7 +164,7 @@ impl Database {
 	/// let info        = Database::from_env().unwrap();
 	/// let colors: i16 = info.get::<cap::MaxColors>().unwrap().into();
 	/// ```
-	pub fn get<'a, C: Capability<'a>>(&'a self) -> Option<C> {
+	pub fn get<C: ?Sized + Capability>(&self) -> Option<&C> {
 		C::lookup(self)
 	}
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -165,7 +165,7 @@ impl Database {
 	/// let colors: i16 = info.get::<cap::MaxColors>().unwrap().into();
 	/// ```
 	pub fn get<'a, C: Capability<'a>>(&'a self) -> Option<C> {
-		C::parse(self.inner.get(C::name()))
+		C::lookup(self)
 	}
 
 	/// Get a capability by name.

--- a/src/parser/compiled.rs
+++ b/src/parser/compiled.rs
@@ -228,9 +228,9 @@ mod test {
 	#[test]
 	fn standard() {
 		load("tests/st-256color", |db| {
-			assert_eq!(Some(cap::Columns(80)), db.get::<cap::Columns>());
-			assert_eq!(Some(cap::AutoRightMargin(true)), db.get::<cap::AutoRightMargin>());
-			assert_eq!(Some(cap::AutoLeftMargin(false)), db.get::<cap::AutoLeftMargin>());
+			assert_eq!(Some(&cap::Columns(80)), db.get::<cap::Columns>());
+			assert_eq!(Some(&cap::AutoRightMargin(true)), db.get::<cap::AutoRightMargin>());
+			assert_eq!(Some(&cap::AutoLeftMargin(false)), db.get::<cap::AutoLeftMargin>());
 		});
 	}
 


### PR DESCRIPTION
(If you'd like me to break these into multiple PRs, I'd be happy to).

Tweaks:

1. Implement `From`, not `Into`. There's a blanket impl from `From` to `Into` so
if you implement the former, you get the latter (but not vice versa).

2. Invert the capability lookup logic. Passing around `Option<&Value>`s seemed
kind of unclean.

Major change:

Make capabilities DSTs and return references to them. How, you say? Well,
`struct NewType(OtherType)` as the same representation as `OtherType` so you can
"safely" (using `unsafe`) cast a `&OtherType` to a `&NewType`. Why, you ask? It
better mirrors `Database::raw` and I don't like seeing `<'a>` in types.

Thoughts?