### PR TITLE
update to nom 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories  = ["command-line-interface"]
 build = "build.rs"
 
 [dependencies]
-nom = "4.0"
+nom = "5.0"
 phf = "0.7"
 fnv = "1.0"
 

--- a/src/parser/expansion.rs
+++ b/src/parser/expansion.rs
@@ -12,7 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-use nom::{is_digit};
+use nom::character::{is_digit};
 use parser::util::number;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]

--- a/src/parser/source.rs
+++ b/src/parser/source.rs
@@ -14,7 +14,7 @@
 
 use std::borrow::Cow;
 use std::str;
-use nom::{is_digit, eol};
+use nom::character::{is_digit, streaming::line_ending as eol};
 use parser::util::{is_printable_no_pipe, is_printable_no_comma, is_printable_no_control};
 use parser::util::{is_eol, is_ws, ws, end};
 use parser::util::unescape;
@@ -41,7 +41,7 @@ named!(pub parse<Item>,
 named!(comment<Item>,
 	do_parse!(
 		tag!("#") >>
-		content: map_res!(take_until_and_consume!("\n"), str::from_utf8) >>
+		content: map_res!(terminated!(take_until!("\n"), tag!("\n")), str::from_utf8) >>
 		take_while!(is_eol) >>
 
 		(Item::Comment(content.trim()))));

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -15,7 +15,7 @@
 use std::str;
 use std::u8;
 use std::borrow::Cow;
-use nom::{eol, is_digit};
+use nom::character::{streaming::line_ending as eol, is_digit};
 
 macro_rules! take_until_or_eof (
   ($i:expr, $substr:expr) => (


### PR DESCRIPTION
reintroduce the cond_reduce combinator that was removed from nom 5

a parser test is failing, but it was already failing before the update, sooooo :D