### PR TITLE
Drop nom's lexical feature, reducing the sub-dependency count.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 [dependencies]
 dirs = "2"
-nom = "5.0"
+nom = { version = "5.0", default-features = false, features = ["std"] }
 phf = "0.8"
 fnv = "1.0"
 


### PR DESCRIPTION
Before:

```
$ cargo tree -e no-build
terminfo v0.7.2 (/home/speed/src/rust-terminfo)
├── dirs v2.0.2
│   ├── cfg-if v0.1.10
│   └── dirs-sys v0.3.4
│       ├── cfg-if v0.1.10
│       └── libc v0.2.70
├── fnv v1.0.7
├── nom v5.1.1
│   ├── lexical-core v0.6.2
│   │   ├── arrayvec v0.4.12
│   │   │   └── nodrop v0.1.14
│   │   ├── cfg-if v0.1.10
│   │   ├── ryu v1.0.4
│   │   └── static_assertions v0.3.4
│   └── memchr v2.3.3
└── phf v0.8.0
    └── phf_shared v0.8.0
        └── siphasher v0.3.3
```

After:
```
$ cargo tree -e no-build
terminfo v0.7.2 (/home/speed/src/rust-terminfo)
├── dirs v2.0.2
│   ├── cfg-if v0.1.10
│   └── dirs-sys v0.3.4
│       ├── cfg-if v0.1.10
│       └── libc v0.2.70
├── fnv v1.0.7
├── nom v5.1.1
│   └── memchr v2.3.3
└── phf v0.8.0
    └── phf_shared v0.8.0
        └── siphasher v0.3.3
```