### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,13 @@ terminfo
 
 Terminal capabilities with type-safe getters.
 
-Usage
------
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-terminfo = "0.1"
-```
-
-and this to your crate root:
-
-```rust
-extern crate terminfo;
-```
-
 Example
 -------
 ```rust
 extern crate terminfo;
 
-use std::io::{self, Write};
-use terminfo::{Expand, Database, capability as cap};
+use std::io;
+use terminfo::{Database, capability as cap};
 
 fn main() {
   let info = Database::from_env().unwrap();
@@ -38,11 +23,16 @@ fn main() {
   }
 
   if let Some(flash) = info.get::<cap::FlashScreen>() {
-    io::stdout().write_all(&flash.expand(&[], &mut Default::default()).unwrap()).unwrap();
+		flash.expand().to(io::stdout()).unwrap();
   }
-  else {
-    println!("FLASH GORDON!");
-  }
+	else {
+		println!("FLASH GORDON!");
+	}
+
+	info.get::<cap::SetAForeground>().unwrap().expand().color(2).to(io::stdout()).unwrap();
+	info.get::<cap::SetABackground>().unwrap().expand().color(4).to(io::stdout()).unwrap();
+	println!("SUP");
+	info.get::<cap::ExitAttributeMode>().unwrap().expand().to(io::stdout()).unwrap();
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,10 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+extern {}
+
 #[macro_use]
 extern crate nom;
 extern crate phf;


### PR DESCRIPTION
* The “usage” section has been removed, because [it now exists on crates.io](https://crates.io/crates/terminfo) — additionally, `extern crate` is no longer really necessary.
* The README example now compiles — I just copied over the code from `examples/simple.rs`. To ensure it continues to compile, I used a little trick in `lib.rs` to run the code in it as a doctest.

Closes #14