### PR TITLE
Upgrade to Nom 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 [dependencies]
 dirs = "4"
-nom = { version = "6", default-features = false, features = ["std"] }
+nom = { version = "7", default-features = false, features = ["std"] }
 phf = "0.11"
 fnv = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 [dependencies]
 dirs = "4"
-nom = { version = "5", default-features = false, features = ["std"] }
+nom = { version = "6", default-features = false, features = ["std"] }
 phf = "0.11"
 fnv = "1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
-#[macro_use]
 extern crate nom;
 extern crate phf;
 extern crate fnv;

--- a/src/parser/expansion.rs
+++ b/src/parser/expansion.rs
@@ -12,6 +12,7 @@
 //
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
+use nom::bytes::complete;
 use nom::character::{is_digit};
 use crate::parser::util::number;
 
@@ -112,7 +113,7 @@ named!(pub parse<Item>,
 	alt!(expansion | string));
 
 named!(string<Item>,
-	map!(take_until_or_eof!("%"), |s| Item::String(s)));
+	map!(complete::take_till(|b| b == b'%'), |s| Item::String(s)));
 
 named!(expansion<Item>,
 	do_parse!(

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -17,33 +17,6 @@ use std::u8;
 use std::borrow::Cow;
 use nom::character::{streaming::line_ending as eol, is_digit};
 
-macro_rules! take_until_or_eof (
-  ($i:expr, $substr:expr) => (
-    {
-      use $crate::nom::InputLength;
-      use $crate::nom::FindSubstring;
-      use $crate::nom::Slice;
-
-      let ret: $crate::nom::IResult<_, _> = if $substr.input_len() > $i.input_len() {
-        Err($crate::nom::Err::Incomplete($crate::nom::Needed::Size($substr.input_len())))
-      }
-			else {
-        match ($i).find_substring($substr) {
-          None => {
-            Ok(($i.slice(0..0), $i))
-          },
-
-          Some(index) => {
-            Ok(($i.slice(index..), $i.slice(0..index)))
-          },
-        }
-      };
-
-      ret
-    }
-  );
-);
-
 const NONE:    u8 = 0b000000;
 const PRINT:   u8 = 0b000001;
 const SPACE:   u8 = 0b000010;

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -15,7 +15,11 @@
 use std::str;
 use std::u8;
 use std::borrow::Cow;
+use nom::branch::alt;
 use nom::character::{streaming::line_ending as eol, is_digit};
+use nom::character::streaming::char;
+use nom::combinator::eof;
+use nom::IResult;
 
 const NONE:    u8 = 0b000000;
 const PRINT:   u8 = 0b000001;
@@ -86,11 +90,13 @@ pub fn is_printable_no_control(ch: u8) -> bool {
 	unsafe { ASCII.get_unchecked(ch as usize) & (PRINT | CONTROL) == PRINT }
 }
 
-named!(pub ws<char>,
-	alt!(char!(' ') | char!('\t')));
+pub fn ws(input: &[u8]) -> IResult<&[u8], char> {
+	alt((char(' '), char('\t')))(input)
+}
 
-named!(pub end,
-	alt!(eof!() | eol));
+pub fn end(input: &[u8]) -> IResult<&[u8], &[u8]> {
+	alt((eof, eol))(input)
+}
 
 #[inline]
 pub fn number(i: &[u8]) -> i32 {


### PR DESCRIPTION
Nom 5 and 6 give build warnings in current Rust nightly that will become errors in future Rust versions:

```console
$ cargo build
   Compiling terminfo v0.7.5 (/home/anders/rust/rust-terminfo)
    Finished dev [unoptimized + debuginfo] target(s) in 1.83s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 417`
```

The actual warnings are many copies of

```
> warning: trailing semicolon in macro used in expression position
>    --> /home/anders/.cargo/registry/src/github.com-1ecc6299db9ec823/nom-5.1.2/src/branch/macros.rs:520:90
>     |
> 520 | ...option::Option::None), $($rest)*);
>     |                                     ^
>     |
>    ::: /home/anders/.cargo/registry/src/github.com-1ecc6299db9ec823/nom-5.1.2/src/branch/mod.rs:263:1
>     |
> 263 | permutation_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ J, FnK K, FnL L, FnM M, FnN N, FnO O, FnP P, FnQ Q, FnR R, FnS S, FnT T, FnU ...
>     | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `permutation_init` which comes from the expansion of the macro `permutation_trait` (in Nightly builds, run with -Z macro-backtrace for more info)
```