### PR TITLE
Remove no-op `parameters` methods on `Expansion`

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -254,14 +254,6 @@ macro_rules! define {
 
 	(string $ident:ident => $capability:expr) => (
 		define!(string define $ident => $capability);
-
-		impl<'a> Expansion<'a, $ident<'a>> {
-			/// Pass all expansion parameters at once.
-			#[inline]
-			pub fn parameters(self) -> Self {
-				self
-			}
-		}
 	);
 
 	(string $ident:ident => $capability:expr; $($rest:tt)+) => (


### PR DESCRIPTION
I don’t think these methods are really worth it. They make the docs of `Expansion` very long to read and are just not useful.