### PR TITLE
Remove `parser` module from public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod error;
 pub use crate::error::{Error, Result};
 
 /// Parsers for various formats.
-pub mod parser;
+mod parser;
 
 /// String capability expansion.
 #[macro_use]


### PR DESCRIPTION
I don’t think this module should be public — it’s mostly used internally, and I could find no usages of it on grep.app. The downsides to having it public is that it makes `nom` part of the public API.