### PR TITLE
Fix crash when terminfo entry is missing description

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -49,7 +49,7 @@ impl Builder {
 		Ok(Database {
 			name: self.name.ok_or(())?,
 			aliases: self.aliases,
-			description: self.description.ok_or(())?,
+			description: self.description.unwrap_or_default(),
 			inner: self.inner,
 		})
 	}

--- a/src/parser/compiled.rs
+++ b/src/parser/compiled.rs
@@ -41,7 +41,9 @@ impl<'a> From<Database<'a>> for crate::Database {
 
 		let mut database = crate::Database::new();
 
-		database.name(names.remove(0)).description(names.pop().unwrap()).aliases(names);
+		database.name(names.remove(0));
+		names.pop().map(|name| database.description(name));
+		database.aliases(names);
 
 		for (index, _) in source.standard.booleans.iter().enumerate().filter(|&(_, &value)| value) {
 			if let Some(&name) = names::BOOLEAN.get(&(index as u16)) {


### PR DESCRIPTION
This fixes a problem with the rio terminal as reported in
https://github.com/fish-shell/fish-shell/pull/10359#issuecomment-2031100387
