### PR TITLE
Fix clippy warnings about fully-capitalized enum variants

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -340,12 +340,12 @@ impl Expand for [u8] {
 								}
 							}
 
-							Binary::AND => x & y,
-							Binary::OR => x | y,
-							Binary::XOR => x ^ y,
+							Binary::BitwiseAnd => x & y,
+							Binary::BitwiseOr => x | y,
+							Binary::BitwiseXor => x ^ y,
 
-							Binary::And => (x != 0 && y != 0) as i32,
-							Binary::Or => (x != 0 || y != 0) as i32,
+							Binary::LogicalAnd => (x != 0 && y != 0) as i32,
+							Binary::LogicalOr => (x != 0 || y != 0) as i32,
 
 							Binary::Equal => (x == y) as i32,
 							Binary::Greater => (x > y) as i32,
@@ -360,8 +360,8 @@ impl Expand for [u8] {
 
 				Item::Operation(Operation::Unary(operation)) => match stack.pop() {
 					Some(Parameter::Number(x)) => stack.push(Parameter::Number(match operation {
-						Unary::Not => (x != 0) as i32,
-						Unary::NOT => !x,
+						Unary::LogicalNot => (x != 0) as i32,
+						Unary::BitwiseNot => !x,
 					})),
 
 					Some(_) => return Err(error::Expand::TypeMismatch.into()),
@@ -377,7 +377,7 @@ impl Expand for [u8] {
 
 							Format::Oct => (value as f32).abs().log(8.0).floor() as usize + 1,
 
-							Format::Hex | Format::HEX => {
+							Format::LowerHex | Format::UpperHex => {
 								(value as f32).abs().log(16.0).floor() as usize + 1
 							}
 
@@ -399,7 +399,7 @@ impl Expand for [u8] {
 						// Add the alternate representation.
 						if p.flags.alternate {
 							match p.format {
-								Format::Hex | Format::HEX => length += 2,
+								Format::LowerHex | Format::UpperHex => length += 2,
 
 								Format::Oct => length += 1,
 
@@ -494,7 +494,7 @@ impl Expand for [u8] {
 							f!(after value);
 						}
 
-						(Format::Hex, Some(Parameter::Number(value))) => {
+						(Format::LowerHex, Some(Parameter::Number(value))) => {
 							f!(before value);
 
 							if p.flags.alternate {
@@ -506,7 +506,7 @@ impl Expand for [u8] {
 							f!(after value);
 						}
 
-						(Format::HEX, Some(Parameter::Number(value))) => {
+						(Format::UpperHex, Some(Parameter::Number(value))) => {
 							f!(before value);
 
 							if p.flags.alternate {

--- a/src/parser/expansion.rs
+++ b/src/parser/expansion.rs
@@ -55,8 +55,8 @@ pub enum Operation {
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub enum Unary {
-	Not,
-	NOT,
+	LogicalNot,
+	BitwiseNot,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
@@ -67,12 +67,12 @@ pub enum Binary {
 	Divide,
 	Remainder,
 
-	AND,
-	OR,
-	XOR,
+	BitwiseAnd,
+	BitwiseOr,
+	BitwiseXor,
 
-	And,
-	Or,
+	LogicalAnd,
+	LogicalOr,
 
 	Equal,
 	Greater,
@@ -100,8 +100,8 @@ pub enum Format {
 	Str,
 	Dec,
 	Oct,
-	Hex,
-	HEX,
+	LowerHex,
+	UpperHex,
 }
 
 #[derive(Eq, PartialEq, Copy, Clone, Default, Debug)]
@@ -193,14 +193,14 @@ fn operation(input: &[u8]) -> IResult<&[u8], Item<'_>> {
 		b"m" => Ok((input, Item::Operation(Operation::Binary(Binary::Remainder)))),
 		b"i" => Ok((input, Item::Operation(Operation::Increment))),
 
-		b"&" => Ok((input, Item::Operation(Operation::Binary(Binary::AND)))),
-		b"|" => Ok((input, Item::Operation(Operation::Binary(Binary::OR)))),
-		b"^" => Ok((input, Item::Operation(Operation::Binary(Binary::XOR)))),
-		b"~" => Ok((input, Item::Operation(Operation::Unary(Unary::NOT)))),
+		b"&" => Ok((input, Item::Operation(Operation::Binary(Binary::BitwiseAnd)))),
+		b"|" => Ok((input, Item::Operation(Operation::Binary(Binary::BitwiseOr)))),
+		b"^" => Ok((input, Item::Operation(Operation::Binary(Binary::BitwiseXor)))),
+		b"~" => Ok((input, Item::Operation(Operation::Unary(Unary::BitwiseNot)))),
 
-		b"A" => Ok((input, Item::Operation(Operation::Binary(Binary::And)))),
-		b"O" => Ok((input, Item::Operation(Operation::Binary(Binary::Or)))),
-		b"!" => Ok((input, Item::Operation(Operation::Unary(Unary::Not)))),
+		b"A" => Ok((input, Item::Operation(Operation::Binary(Binary::LogicalAnd)))),
+		b"O" => Ok((input, Item::Operation(Operation::Binary(Binary::LogicalOr)))),
+		b"!" => Ok((input, Item::Operation(Operation::Unary(Unary::LogicalNot)))),
 
 		b"=" => Ok((input, Item::Operation(Operation::Binary(Binary::Equal)))),
 		b">" => Ok((input, Item::Operation(Operation::Binary(Binary::Greater)))),
@@ -252,8 +252,8 @@ fn print(input: &[u8]) -> IResult<&[u8], Item<'_>> {
 			format: match format {
 				'd' => Format::Dec,
 				'o' => Format::Oct,
-				'x' => Format::Hex,
-				'X' => Format::HEX,
+				'x' => Format::LowerHex,
+				'X' => Format::UpperHex,
 				's' => Format::Str,
 				'c' => Format::Chr,
 				'u' => Format::Uni,
@@ -340,25 +340,25 @@ mod test {
 			Operation(Operation::Binary(Binary::Remainder)));
 
 		test!(b"%&" =>
-			Operation(Operation::Binary(Binary::AND)));
+			Operation(Operation::Binary(Binary::BitwiseAnd)));
 
 		test!(b"%|" =>
-			Operation(Operation::Binary(Binary::OR)));
+			Operation(Operation::Binary(Binary::BitwiseOr)));
 
 		test!(b"%^" =>
-			Operation(Operation::Binary(Binary::XOR)));
+			Operation(Operation::Binary(Binary::BitwiseXor)));
 
 		test!(b"%~" =>
-			Operation(Operation::Unary(Unary::NOT)));
+			Operation(Operation::Unary(Unary::BitwiseNot)));
 
 		test!(b"%A" =>
-			Operation(Operation::Binary(Binary::And)));
+			Operation(Operation::Binary(Binary::LogicalAnd)));
 
 		test!(b"%O" =>
-			Operation(Operation::Binary(Binary::Or)));
+			Operation(Operation::Binary(Binary::LogicalOr)));
 
 		test!(b"%!" =>
-			Operation(Operation::Unary(Unary::Not)));
+			Operation(Operation::Unary(Unary::LogicalNot)));
 
 		test!(b"%=" =>
 			Operation(Operation::Binary(Binary::Equal)));


### PR DESCRIPTION
That fixes the remaining warnings reported by clippy in the current stable and nightly Rust.